### PR TITLE
Specify ruby-yaml 1.8.x in gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     spid-rails (0.1.2)
       rails (~> 5.1, >= 5.1.4)
       rails-html-sanitizer (~> 1.0, >= 1.0.4)
-      ruby-saml (= 1.5.0)
+      ruby-saml (~> 1.8.0)
 
 GEM
   remote: https://rubygems.org/
@@ -104,7 +104,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.3.1)
-    ruby-saml (1.5.0)
+    ruby-saml (1.8.0)
       nokogiri (>= 1.5.10)
     simplecov (0.16.1)
       docile (~> 1.1)

--- a/spid-rails.gemspec
+++ b/spid-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "rails", "~> 5.1", ">= 5.1.4"
-  s.add_dependency "ruby-saml", "1.5.0"
+  s.add_dependency "ruby-saml", "~> 1.8.0"
 
   # Resolve CVE-2018-3741  vulnerability
   s.add_dependency "rails-html-sanitizer", "~> 1.0", ">= 1.0.4"


### PR DESCRIPTION
La versione 1.5.0 di ruby-saml presentava una vulnerabilità (https://github.com/onelogin/ruby-saml#updating-from-160-to-170). Ho impostato nel gemspec l'utilizzo delle versioni 1.8.x 