### PR TITLE
Utilizzo spid-testenv2

### DIFF
--- a/app/models/spid/idp.rb
+++ b/app/models/spid/idp.rb
@@ -12,7 +12,8 @@ module Spid
         'poste_test' => 'http://spidposte.test.poste.it/jod-fs/metadata/idp.xml',
         'spiditalia' => 'https://spid.register.it/login/metadata',
         'sielte'     => 'https://identity.sieltecloud.it/simplesaml/metadata.xml',
-        'tim'        => 'https://login.id.tim.it/spid-services/MetadataBrowser/idp'
+        'tim'        => 'https://login.id.tim.it/spid-services/MetadataBrowser/idp',
+        'testenv2'   => 'http://spid-testenv:8088/metadata'
       }
     end
 

--- a/app/models/spid/settings.rb
+++ b/app/models/spid/settings.rb
@@ -64,7 +64,7 @@ module Spid
       idp_bindings = @bindings.map { |b| self.class.saml_bindings[b] }
       parser = OneLogin::RubySaml::IdpMetadataParser.new
       parser.parse_remote_to_hash Idp.metadata_urls[@idp.to_s],
-                                  true,
+                                  false,
                                   sso_binding: idp_bindings
     end
 

--- a/app/models/spid/settings.rb
+++ b/app/models/spid/settings.rb
@@ -51,7 +51,7 @@ module Spid
 
     def sp_attributes
       {
-        issuer: host + metadata_path,
+        issuer: host,
         assertion_consumer_service_url: host + sso_path,
         single_logout_service_url: host + slo_path,
         private_key: File.read("#{::Rails.root}/#{keys_path}/private_key.pem"),


### PR DESCRIPTION
Con queste modifiche è possibile utilizzare l'ambiente spid-testenv 2 per fare simulazioni in locale del corretto funzionamento di spid-rails
