### PR TITLE
Valida certificato del metadata Idp se non di test

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)

--- a/app/models/spid/settings.rb
+++ b/app/models/spid/settings.rb
@@ -79,7 +79,7 @@ module Spid
     end
 
     def validate_idp_metadata_cert?
-      true unless @idp == 'testenv2'
+      @idp != 'testenv2' ? true : false
     end
 
     # TODO spostare in utils

--- a/app/models/spid/settings.rb
+++ b/app/models/spid/settings.rb
@@ -79,7 +79,7 @@ module Spid
     end
 
     def validate_idp_metadata_cert?
-      @idp != 'testenv2' ? true : false
+      @idp == 'testenv2' ? false : true
     end
 
     # TODO spostare in utils

--- a/app/models/spid/settings.rb
+++ b/app/models/spid/settings.rb
@@ -79,7 +79,7 @@ module Spid
     end
 
     def validate_idp_metadata_cert?
-      @idp == 'testenv2' ? false : true
+      !(@idp == 'testenv2')
     end
 
     # TODO spostare in utils

--- a/app/models/spid/settings.rb
+++ b/app/models/spid/settings.rb
@@ -64,7 +64,7 @@ module Spid
       idp_bindings = @bindings.map { |b| self.class.saml_bindings[b] }
       parser = OneLogin::RubySaml::IdpMetadataParser.new
       parser.parse_remote_to_hash Idp.metadata_urls[@idp.to_s],
-                                  false,
+                                  validate_idp_metadata_cert?,
                                   sso_binding: idp_bindings
     end
 
@@ -76,6 +76,10 @@ module Spid
 
     def force_authn
       return true if @spid_level != 1
+    end
+
+    def validate_idp_metadata_cert?
+      true unless @idp == 'testenv2'
     end
 
     # TODO spostare in utils

--- a/app/models/spid/settings.rb
+++ b/app/models/spid/settings.rb
@@ -79,7 +79,7 @@ module Spid
     end
 
     def validate_idp_metadata_cert?
-      !(@idp == 'testenv2')
+      @idp != 'testenv2'
     end
 
     # TODO spostare in utils


### PR DESCRIPTION
Il controllo del certificato viene skippato solo se la richiesta viene effettuata all'Idp di test.