### PR TITLE
Allow SLO with Redirect Binding

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,10 +2,6 @@ Rails.application.routes.draw do
   mount Spid::Rails::Engine, at: Spid::Rails.mount_point
 end
 
-Rails.application.routes.draw do
-  mount Spid::Rails::Engine, at: Spid::Rails.mount_point
-end
-
 Spid::Rails::Engine.routes.draw do
   resource :metadata, only: :show,
                       path: Spid::Rails.metadata_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,5 @@ Spid::Rails::Engine.routes.draw do
                  path: Spid::Rails.sso_path
   resource :slo, only: [:new, :create], controller: :single_logout_operations,
                  path: Spid::Rails.slo_path
-  get Spid::Rails.slo_path, to: "single_logout_operations#create"
+  get Spid::Rails.slo_path, to: 'single_logout_operations#create'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,12 +2,19 @@ Rails.application.routes.draw do
   mount Spid::Rails::Engine, at: Spid::Rails.mount_point
 end
 
+Rails.application.routes.draw do
+  mount Spid::Rails::Engine, at: Spid::Rails.mount_point
+end
+
 Spid::Rails::Engine.routes.draw do
   resource :metadata, only: :show,
                       path: Spid::Rails.metadata_path
-  resource :sso, only: [:new, :create], controller: :single_sign_ons,
+  resource :sso, only: [:new, :create],
+                 controller: :single_sign_ons,
                  path: Spid::Rails.sso_path
-  resource :slo, only: [:new, :create], controller: :single_logout_operations,
-                 path: Spid::Rails.slo_path
-  get Spid::Rails.slo_path, to: 'single_logout_operations#create'
+  resource :slo, only: [:new, :create],
+                 controller: :single_logout_operations,
+                 path: Spid::Rails.slo_path do
+                   get '/', to: 'single_logout_operations#create'
+                 end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,5 @@ Spid::Rails::Engine.routes.draw do
                  path: Spid::Rails.sso_path
   resource :slo, only: [:new, :create], controller: :single_logout_operations,
                  path: Spid::Rails.slo_path
+  get Spid::Rails.slo_path, to: "single_logout_operations#create"
 end


### PR DESCRIPTION
Il metadata default con ruby-saml prevede di default il binding di tipo Redirect, il che implica la possibiltà di ricevere la SAMLResponse del LogoutRequest anche tramite verbo GET